### PR TITLE
made creating the driver work on Windows

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -136,10 +136,14 @@
                 procs)
           procs)))
 
+(if (string-equal system-type "windows-nt")
+    (setq ob-ipython-python-executable-search-string "python.exe")
+    (setq ob-ipython-python-executable-search-string "python"))
+
 (defun ob-ipython--create-driver ()
   (when (not (process-live-p (ob-ipython--get-driver-process)))
     (ob-ipython--create-process "ob-ipython-driver"
-                                (list (locate-file "python" exec-path)
+                                (list (locate-file ob-ipython-python-executable-search-string exec-path)
                                       ob-ipython-driver-path
                                       (number-to-string ob-ipython-driver-port)))
     ;; give driver a chance to bind to a port and start serving


### PR DESCRIPTION
this commit adds a variable, `ob-ipython-python-executable-search-string` that is set to "python.exe" if the system type is "windows-nt". Otherwise, it is set to "python". This change fixes https://github.com/gregsexton/ob-ipython/issues/4

However, I have only been able to test on windows, so someone should test on Linux/OSX to be sure it doesn't mess anything up there.