### PR TITLE
Encode text

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -289,7 +289,7 @@ This function is called by `org-babel-execute-src-block'."
     (org-babel-ipython-initiate-session session)
     (-when-let (ret (ob-ipython--eval
                      (ob-ipython--execute-request
-                      (org-babel-expand-body:generic body params (org-babel-variable-assignments:python params))
+                      (org-babel-expand-body:generic (encode-coding-string body 'raw-text) params (org-babel-variable-assignments:python params))
                       (ob-ipython--normalize-session session))))
       (let ((result (cdr (assoc :result ret)))
             (output (cdr (assoc :output ret))))


### PR DESCRIPTION
This is necessary for non-ascii text.