### PR TITLE
Fix #15: Adding support for org tables from pandas.DataFrame

### DIFF
--- a/LICENSES/PANDAS
+++ b/LICENSES/PANDAS
@@ -1,0 +1,69 @@
+=======
+License
+=======
+pandas is distributed under a 3-clause ("Simplified" or "New") BSD
+license. Parts of NumPy, SciPy, numpydoc, bottleneck, which all have
+BSD-compatible licenses, are included. Their licenses follow the pandas
+license.
+pandas license
+==============
+Copyright (c) 2011-2012, Lambda Foundry, Inc. and PyData Development Team
+All rights reserved.
+Copyright (c) 2008-2011 AQR Capital Management, LLC
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+* Neither the name of the copyright holder nor the names of any
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+About the Copyright Holders
+===========================
+AQR Capital Management began pandas development in 2008. Development was
+led by Wes McKinney. AQR released the source under this license in 2009.
+Wes is now an employee of Lambda Foundry, and remains the pandas project
+lead.
+The PyData Development Team is the collection of developers of the PyData
+project. This includes all of the PyData sub-projects, including pandas. The
+core team that coordinates development on GitHub can be found here:
+http://github.com/pydata.
+Full credits for pandas contributors can be found in the documentation.
+Our Copyright Policy
+====================
+PyData uses a shared copyright model. Each contributor maintains copyright
+over their contributions to PyData. However, it is important to note that
+these contributions are typically only changes to the repositories. Thus,
+the PyData source code, in its entirety, is not the copyright of any single
+person or institution. Instead, it is the collective copyright of the
+entire PyData Development Team. If individual contributors want to maintain
+a record of what changes/contributions they have specific copyright on,
+they should indicate their copyright in the commit message of the change
+when they commit the change to one of the PyData repositories.
+With this in mind, the following banner should be used in any source code
+file to indicate the copyright and license terms:
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012, PyData Development Team
+# All rights reserved.
+#
+# Distributed under the terms of the BSD Simplified License.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+Other licenses can be found in the LICENSES directory.

--- a/df_to_org.py
+++ b/df_to_org.py
@@ -1,0 +1,90 @@
+from pandas import MultiIndex, DataFrame
+from pandas.core.format import DataFrameFormatter
+
+def sepjoin(sep, *lists):
+    lengths = [max(map(len, x)) for x in lists]
+    form = sep.join("{:<%d}" % l for l in lengths)
+    tojoin = zip(*lists)
+    return [form.format(*line) for line in tojoin]
+
+class DFOrgFormatter(DataFrameFormatter):
+    def _get_formatted_index_org(self, frame):
+        # Taken from DataFrameFormatter to remove join of index
+        index = frame.index
+        columns = frame.columns
+
+        show_index_names = self.show_index_names and self.has_index_names
+        show_col_names = (self.show_index_names and self.has_column_names)
+
+        fmt = self._get_formatter('__index__')
+
+        if isinstance(index, MultiIndex):
+            fmt_index = index.format(sparsify=self.sparsify, adjoin=False,
+                                     names=show_index_names,
+                                     formatter=fmt)
+        else:
+            fmt_index = [index.format(name=show_index_names, formatter=fmt)]
+        fmt_index = [list(x) for x in fmt_index]
+        # empty space for columns
+        blank = [''] * columns.nlevels
+        if show_col_names:
+            col_header = ['%s' % x for x in self._get_column_name_list()]
+        else:
+            col_header = blank
+
+        if self.header:
+            fmt_index_1 = [blank + index for index in fmt_index[:-1]]
+            fmt_index = fmt_index_1 + [col_header + fmt_index[-1]]
+            return fmt_index
+        else:
+            return fmt_index
+
+    def to_org(self):
+        frame = self.frame
+        buf = self.buf
+        strcols = self._to_str_columns()[1:]
+
+        if self.index:
+            strcols = self._get_formatted_index_org(frame) + strcols
+
+        lengths = [max(map(len, x)) for x in strcols]
+        lines = sepjoin(" | ", *strcols)
+
+
+        col_nlevels = frame.columns.nlevels
+        if self.show_index_names and self.has_index_names:
+            col_nlevels = col_nlevels + 1
+        for i, row in enumerate(lines):
+            if i == col_nlevels:
+                hline = "|-" + "-+-".join("-"*l for l in lengths) + "-|\n"
+                buf.write(hline)
+                if self.index:
+                    ind_nlevels = frame.index.nlevels
+                    cols = [" "*l for l in lengths]
+                    cols[0] = "/"+cols[0][1:]
+                    cols[ind_nlevels] = "<"+cols[ind_nlevels][1:]
+                    buf.write("| " + " | ".join(cols) + " |\n")
+            buf.write("| " + row + " |\n")
+
+def to_org(frame, **kwds):
+    formatter = DFOrgFormatter(frame, **kwds)
+    formatter.to_org()
+    return formatter.buf.getvalue()
+
+try:
+    from IPython.core.formatters import BaseFormatter, Unicode, ObjectName
+except ImportError:
+    pass
+else:
+    class IPyOrgFormatter(BaseFormatter):
+        format_type = Unicode('text/x-org')
+
+        print_method = ObjectName('_repr_org_')
+
+    def register_orgformatter():
+        from IPython.core.interactiveshell import InteractiveShell
+        formatter = InteractiveShell.instance().display_formatter
+        orgformatter = IPyOrgFormatter(parent=formatter)
+        formatter.formatters[orgformatter.format_type] = orgformatter
+        formatter.active_types.append(orgformatter.format_type)
+        orgformatter.for_type(DataFrame, to_org)

--- a/df_to_org.py
+++ b/df_to_org.py
@@ -7,6 +7,12 @@ def sepjoin(sep, *lists):
     tojoin = zip(*lists)
     return [form.format(*line) for line in tojoin]
 
+# A Lof of code here is borrowed from pandas (http://pandas.pydata.org/)
+# The BSD license of it can be found in the LICENSE directory
+# ---
+# Copyright (c) 2012, PyData Development Team
+# All rights reserved.
+
 class DFOrgFormatter(DataFrameFormatter):
     def _get_formatted_index_org(self, frame):
         # Taken from DataFrameFormatter to remove join of index
@@ -65,6 +71,7 @@ class DFOrgFormatter(DataFrameFormatter):
                     cols[ind_nlevels] = "<"+cols[ind_nlevels][1:]
                     buf.write("| " + " | ".join(cols) + " |\n")
             buf.write("| " + row + " |\n")
+# ---
 
 def to_org(frame, **kwds):
     formatter = DFOrgFormatter(frame, **kwds)

--- a/driver.py
+++ b/driver.py
@@ -23,7 +23,8 @@ def remove_handlers(msgid):
 
 def get_handler(msg):
     def ignore(msg): pass
-    acc, final = handlers.get(msg['parent_header']['msg_id'], (ignore, ignore))
+    acc, final = handlers.get(msg['parent_header'].get('msg_id', ''),
+                              (ignore, ignore))
     msg_type = msg.get('msg_type', '')
     if msg_type in ['execute_reply', 'inspect_reply']:
         return final

--- a/test_df.org
+++ b/test_df.org
@@ -1,0 +1,24 @@
+#+BEGIN_SRC ipython :session
+  import pandas as pd
+  import df_to_org
+  df_to_org.register_orgformatter()
+#+END_SRC
+
+#+RESULTS:
+
+#+BEGIN_SRC ipython :session :results value
+df2 = pd.DataFrame({ 'A' : 1.,
+                     'B' : pd.Timestamp('20130202'),
+                     'C' : pd.Series(range(1,5),index=list(range(4)),dtype='float32'),
+                     'F' : 'foo' })
+df2
+#+END_SRC
+
+#+RESULTS:
+|   | A |          B | C | F   |
+|---+---+------------+---+-----|
+| / | < |            |   |     |
+| 0 | 1 | 2013-02-02 | 1 | foo |
+| 1 | 1 | 2013-02-02 | 2 | foo |
+| 2 | 1 | 2013-02-02 | 3 | foo |
+| 3 | 1 | 2013-02-02 | 4 | foo |


### PR DESCRIPTION
This is a prototype to convert pandas.DataFrames to org syntax and display them in org-mode.
Any comments are very welcome.
