### PR TITLE
support custom hostname setting for HTTP driver

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -50,6 +50,10 @@
 (defcustom ob-ipython-driver-port 9988
   "Port to use for http driver."
   :group 'ob-ipython)
+  
+(defcustom ob-ipython-driver-hostname "localhost"
+  "Hostname to use for http driver."
+  :group 'ob-ipython)
 
 (defcustom ob-ipython-driver-path
   (f-expand "./driver.py"
@@ -187,7 +191,10 @@ a new kernel will be started."
   (let ((url-request-data code)
         (url-request-method "POST"))
     (with-current-buffer (url-retrieve-synchronously
-                          (format "http://localhost:%d/execute/%s" ob-ipython-driver-port name))
+                          (format "http://%s:%d/execute/%s" 
+                            ob-ipython-driver-hostname
+                            ob-ipython-driver-port
+                            name))
       (if (>= (url-http-parse-response) 400)
     (ob-ipython--dump-error (buffer-string))
   (goto-char url-http-end-of-headers)
@@ -246,7 +253,9 @@ a new kernel will be started."
         (url-request-method "POST"))
     (with-current-buffer (url-retrieve-synchronously
                           ;; TODO: hardcoded the default session here
-                          (format "http://localhost:%d/inspect/default" ob-ipython-driver-port))
+                          (format "http://%s:%d/inspect/default"
+                            ob-ipython-driver-hostname
+                            ob-ipython-driver-port))
       (if (>= (url-http-parse-response) 400)
           (ob-ipython--dump-error (buffer-string))
         (goto-char url-http-end-of-headers)


### PR DESCRIPTION
This makes it possible to connect to any (including remote) host requested, as discussed in #11.
Essentially it just extends the `format` call with another custom setting.
However, as discussed in #11, `:port` and `:host` header arguments might be a better and more flexible approach with these setting serving only as defaults.