### PR TITLE
support both IPython3 and Jupyter by conditional import

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -1,4 +1,9 @@
-import jupyter_client as client
+try:                            # Jupyter and IPython >= 4.0
+    import jupyter_client as client
+    find_connection_file = client.find_connection_file
+except ImportError:             # IPython 3
+    from IPython.lib.kernel import find_connection_file
+    import IPython.kernel.blocking.client as client
 
 import sys
 import threading
@@ -38,7 +43,7 @@ def msg_router(name, ch):
 clients = {}
 
 def create_client(name):
-    cf = client.find_connection_file('emacs-' + name)
+    cf = find_connection_file('emacs-' + name)
     c = client.BlockingKernelClient(connection_file=cf)
     c.load_connection_file()
     c.start_channels()


### PR DESCRIPTION
I would like to propose a simple change that would deal with the current IPython 3/4 dichotomy and it would simplify installation for users as they wouldn't have to deal with git at all and an MELPA installation would suffice.

The code first tries to import the Jupyter libraries, failing that
the IPython 3 libraries are imported. All that really changed are
module names.

This simple compatibility workaround may not work
in the long term if Jupyter code diverges significantly from the current state. But by that time IPython 3 will be hopefully obsolete.

I haven't fully tested it yet with IPython 3, not sure if this will bring #19 back.