### PR TITLE
Using write-region rather than write-file as write-file interacts wit…

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -70,7 +70,7 @@
         (insert b64-string)
         (base64-decode-region (point-min) (point-max))
         (let ((require-final-newline nil))
-          (write-file file)))
+          (write-region (point-min) (point-max) file)))
     (error "No output was produced to write to a file.")))
 
 (defun ob-ipython--create-traceback-buffer (traceback)


### PR DESCRIPTION
…h my system by setting the modified buffer flag and thereby disallowing the image in the buffer to be saved to the file and thus displayed inline. This may have to do with some interaction with the ido package or ?, not sure. Anway this 'fix' works reliably for me such that the buffered image is saved to the file and then displayed inline in org-mode.
