### PR TITLE
Fix driver.py command line args when using ipython

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -154,7 +154,8 @@
   (let* ((python (locate-file (if (eq system-type 'windows-nt)
                                   "python.exe"
                                 (or python-shell-interpreter "python")) exec-path))
-         (pargs (append (list python ob-ipython-driver-path) args)))
+	 ;; we add " -- " before args to python-shell-interpreter, otherwise, if python-shell-interpreter is ipython, ipython itself will attempt to parse the driver.py command line args and error out
+         (pargs (append (list python "--" ob-ipython-driver-path) args)))
     (ob-ipython--create-process name pargs)
     ;; give kernel time to initialize and write connection file
     (sleep-for 1)))


### PR DESCRIPTION
This fixes https://github.com/gregsexton/ob-ipython/issues/63

The bug is caused when starting the client or kernel driver while having
python-shell-interpreter set to ipython. The driver.py command line
arguments (e.g., "--port" or "--conn-file") get parsed by ipython which
doesn't recognize them and exits with an error, without starting
driver.py

This fix appends "--" directly after the python interpreter path, e.g.,

/usr/bin/ipython -- /path/to/driver.py --port 8080

This has the effect of correctly passing the driver.py command line args
to driver.

This change has no effect if python-shell-interpreter is python -
presumably the python interpreter just ignores "--".