### PR TITLE
pass extra arguments to ipython kernel

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -127,7 +127,10 @@ def main(args):
     parser.add_argument('--port', type=int)
     parser.add_argument('--kernel')
     parser.add_argument('--conn-file')
+
+    parser.add_argument('positional', nargs='*')
     args = parser.parse_args()
+    extra_arguments = args.positional
     if args.conn_file:
         if runtime_dir:
             conn_file = (args.conn_file if os.path.isabs(args.conn_file)
@@ -153,7 +156,7 @@ def main(args):
             # Emacs sends SIGHUP upon exit
             signal.signal(signal.SIGHUP, onsignal)
 
-        manager.start_kernel()
+        manager.start_kernel(extra_arguments=extra_arguments)
         try:
             semaphore.acquire()
         except KeyboardInterrupt: pass

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -144,7 +144,11 @@
     (apply 'ob-ipython--launch-driver
            (append (list (format "kernel-%s" name))
                    (list "--conn-file" (format "emacs-%s.json" name))
-                   (if kernel (list "--kernel" kernel) '())))))
+                   (if kernel (list "--kernel" kernel) '())
+                   ;;should be last in the list of args
+                   (if ob-ipython-kernel-extra-args
+                       (list "--") '())
+                   ob-ipython-kernel-extra-args))))
 
 (defun ob-ipython--get-kernel-processes ()
   (let ((procs (-filter (lambda (p)


### PR DESCRIPTION
It was removed in commit https://github.com/gregsexton/ob-ipython/commit/5b8bb63c14226f6a93cb71346e046c8ac19d284d
Now arguments are passed to the driver and then to the kernel.
I use it to specify a profile for kernels, since I have a profile for org-mode that converts dict, tuples, pd.Series to org-mode tables.
