### PR TITLE
Support connecting to existing ipython session.

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,6 +104,8 @@
 
    This is the most basic ipython block. You *must* provide a session
    argument. You can name the session if you wish to separate state.
+   You can also pass an connection json of existing ipython session
+   as a session name in order to connect to it.
 
    #+BEGIN_SRC org
      ,#+BEGIN_SRC ipython :session

--- a/driver.py
+++ b/driver.py
@@ -53,7 +53,11 @@ def msg_router(name, ch):
 clients = {}
 
 def create_client(name):
-    cf = find_connection_file('emacs-' + name)
+    if name.endswith('.json'):
+        # Received an existing kernel we should connect to.
+        cf = find_connection_file(name)
+    else:
+        cf = find_connection_file('emacs-' + name)
     c = client.BlockingKernelClient(connection_file=cf)
     c.load_connection_file()
     c.start_channels()
@@ -117,10 +121,10 @@ class DebugHandler(tornado.web.RequestHandler):
 
 def make_app():
     return tornado.web.Application([
-        tornado.web.url(r"/execute/(\w+)", ExecuteHandler),
-        tornado.web.url(r"/inspect/(\w+)", InspectHandler),
+        tornado.web.url(r"/execute/([\w\-\.]+)", ExecuteHandler),
+        tornado.web.url(r"/inspect/([\w\-\.]+)", InspectHandler),
         tornado.web.url(r"/debug", DebugHandler),
-        ])
+    ])
 
 def main(args):
     parser = argparse.ArgumentParser()

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -129,7 +129,11 @@
 ;;; process management
 
 (defun ob-ipython--kernel-repl-cmd (name)
-  (list "ipython" "console" "--existing" (format "emacs-%s.json" name)))
+  (let ((conn-json
+         (if (s-ends-with-p ".json" name)
+             name
+           (format "emacs-%s.json" name))))
+    (list "ipython" "console" "--existing" conn-json)))
 
 (defun ob-ipython--create-process (name cmd)
   (apply 'start-process name (format "*ob-ipython-%s*" name) (car cmd) (cdr cmd)))
@@ -345,8 +349,9 @@ VARS contains resolved variable references"
       (error "ob-ipython currently only supports evaluation using a session.
 Make sure your src block has a :session param.")
     (ob-ipython--create-client-driver)
-    (ob-ipython--create-kernel-driver (ob-ipython--normalize-session session)
-                                      (cdr (assoc :kernel params)))
+    (when (not (s-ends-with-p ".json" session))
+      (ob-ipython--create-kernel-driver (ob-ipython--normalize-session session)
+                                        (cdr (assoc :kernel params))))
     (ob-ipython--create-repl (ob-ipython--normalize-session session))))
 
 (provide 'ob-ipython)


### PR DESCRIPTION
Use cases:
-   Start an ipython kernel on a server with lots of ram and cpu
  and connect it to local lightweight machine running emacs.
-   Ipython kernel launched by some tool. My team have a tool that
  configures ipython session and configuration can't simply be
  added to ~/.ipython/profile_default.

Simply naming session with connection json is simple solution that works well.
I considered additional parameter, "existing-session", but it would require much more code changes, as it would require passing one more argument in all tornado requests.

I am running it in my emacs and it works. To test:
1.  Start ipython session outside of org mode with:
   
   import os
   from ipykernel.kernelapp import IPKernelApp
   
   app = IPKernelApp.instance()
   app.initialize([])
   kernel = app.kernel
   kernel.shell.push({'print_me': 'Running in previously started kernel.'})
   
   app.start()
2.  Get json from previous command and name a session after your json file. For example:
   # +BEGIN_SRC ipython :session kernel-8520.json :results output
   
     print print_me
   # +END_SRC
   # +RESULTS:
   
   : Running in previously started kernel.
