### PR TITLE
Configure babel blocks for each kernel

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,51 +5,6 @@
    An Emacs library that allows Org mode to evaluate code blocks using
    a Jupyter kernel (Python by default).
 
-*** Why not use IPython notebook?
-
-    I tried using the IPython notebook but quickly became frustrated
-    with trying to write code in a web browser. This provides another
-    option for creating documents containing executable Python code,
-    but in Emacs - with everything that entails.
-
-*** Why not use [[https://millejoh.github.io/emacs-ipython-notebook/][EIN]]?
-
-    EIN is really great. It kept me happy for quite a while but I
-    started to feel constrained by the cell format of IPython
-    notebooks. What I really wanted was to embed code in Org
-    documents. It's hard to compete with Org mode! A few key points in
-    favour of Org:
-
-    * In my opinion, Org's markup is better than Markdown.
-    * Org's organisational, editing and navigation facilities are much
-      better than EIN.
-    * Org's tables...
-    * Org can export to multiple formats.
-    * I like how Org opens a new buffer when editing code so that you
-      can use a Python major mode rather than trying to handle
-      multiple major modes in one.
-
-    I also found myself hitting bugs in EIN where evaluation and doc
-    lookup would just stop working. I regularly had to kill and reopen
-    buffers or restart the IPython kernel and this was getting
-    frustrating.
-
-*** How does this compare to regular Org Python integration (ob-python)?
-
-    I think this is more robust. The executed code is sent to a
-    running IPython kernel which has an architecture designed for this
-    purpose. The way ob-python works feels like a bit of a hack. I ran
-    in to race conditions using ob-python where the Org buffer would
-    update its results before the Python REPL had finished evaluating
-    the code block. This is what eventually drove me to write this.
-
-    It's easier to get plots and images out of this. I also provide
-    several features I missed when using plain ob-python, such as
-    looking up documentation and getting IPython-style tracebacks when
-    things go wrong.
-
-    You can also use IPython-specific features such as ~%timeit~.
-
 ** Screenshot
 
    [[./screenshot.jpg]]
@@ -97,11 +52,14 @@
 
    This is the most basic ipython block. You *must* provide a session
    argument. You can name the session if you wish to separate state.
-   You can also pass an connection json of existing ipython session
+   You can also pass a connection json of an existing ipython session
    as a session name in order to connect to it.
 
+   The result returned by ob-ipython should be renderable by org so
+   it's recommended to always use ~:results raw drawer~.
+
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session
+     ,#+BEGIN_SRC ipython :session :results raw drawer
        %matplotlib inline
        import matplotlib.pyplot as plt
        import numpy as np
@@ -112,7 +70,7 @@
    session.
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session mysession :exports both
+     ,#+BEGIN_SRC ipython :session mysession :exports both :results raw drawer
        def foo(x):
            return x + 9
 
@@ -123,12 +81,22 @@
      : [16, 17, 18, 19, 20, 21, 22]
    #+END_SRC
 
-   This is how you can get a graphic out. Notice the file argument.
-   This must be provided. You must also ensure that you have evaluated
-   ~%matplotlib inline~ before evaluating this.
+   To get a graphic out, you must ensure that you have evaluated
+   ~%matplotlib inline~ first. A file will be generated for you (see
+   the ~ob-ipython-resources-dir~ custom var if you want to change the
+   path).
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both
+     ,#+BEGIN_SRC ipython :session :exports both :results raw drawer
+       plt.hist(np.random.randn(20000), bins=200)
+     ,#+END_SRC
+   #+END_SRC
+
+   If you provide a file argument, this will be used instead of
+   generating one.
+
+   #+BEGIN_SRC org
+     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :results raw drawer
        plt.hist(np.random.randn(20000), bins=200)
      ,#+END_SRC
    #+END_SRC
@@ -176,7 +144,7 @@
    Asynchronous execution is supported. Use the ~:async t~ option.
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :async t
+     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :async t :results raw drawer
        import time
        time.sleep(3)
        plt.hist(np.random.randn(20000), bins=200)
@@ -210,8 +178,8 @@
 
 ** Tips and tricks
 
-   Here are a few things I've setup to make life better. These aren't
-   provided with ob-ipython but are recommended.
+   Here are a few things I have setup to make life better. These
+   aren't provided with ob-ipython, but are recommended.
 
    * Be sure to use ~%matplotlib inline~, otherwise graphics won't work.
 
@@ -248,7 +216,9 @@
        (add-to-list 'org-latex-minted-langs '(ipython "python"))
      #+END_SRC
 
-   * Use [[https://pypi.python.org/pypi/tabulate][tabulate]] to output data frames for org mode.
+   * Install pandoc and anything ipython renders as html will be
+     converted to org. This is mostly useful for getting nice tables
+     automatically.
 
 ** Help, it doesn't work
 
@@ -257,3 +227,49 @@
    project's issues, so take a look there to see if your problem has a
    quick fix. Otherwise feel free to cut an issue - I'll do my best to
    help.
+
+** Alternatives
+*** Why not use IPython notebook?
+
+    I tried using the IPython notebook but quickly became frustrated
+    with trying to write code in a web browser. This provides another
+    option for creating documents containing executable Python code,
+    but in Emacs - with everything that entails.
+
+*** Why not use [[https://millejoh.github.io/emacs-ipython-notebook/][EIN]]?
+
+    EIN is really great. It kept me happy for quite a while but I
+    started to feel constrained by the cell format of IPython
+    notebooks. What I really wanted was to embed code in Org
+    documents. It's hard to compete with Org mode! A few key points in
+    favour of Org:
+
+    * In my opinion, Org's markup is better than Markdown.
+    * Org's organisational, editing and navigation facilities are much
+      better than EIN.
+    * Org's tables...
+    * Org can export to multiple formats.
+    * I like how Org opens a new buffer when editing code so that you
+      can use a Python major mode rather than trying to handle
+      multiple major modes in one.
+
+    I also found myself hitting bugs in EIN where evaluation and doc
+    lookup would just stop working. I regularly had to kill and reopen
+    buffers or restart the IPython kernel and this was getting
+    frustrating.
+
+*** How does this compare to regular Org Python integration (ob-python)?
+
+    I think this is more robust. The executed code is sent to a
+    running IPython kernel which has an architecture designed for this
+    purpose. The way ob-python works feels like a bit of a hack. I ran
+    in to race conditions using ob-python where the Org buffer would
+    update its results before the Python REPL had finished evaluating
+    the code block. This is what eventually drove me to write this.
+
+    It's easier to get plots and images out of this. I also provide
+    several features I missed when using plain ob-python, such as
+    looking up documentation and getting IPython-style tracebacks when
+    things go wrong.
+
+    You can also use IPython-specific features such as ~%timeit~.

--- a/README.org
+++ b/README.org
@@ -228,6 +228,14 @@
 
    * Open a REPL using =C-c C-v C-z= so that you get completion in Python buffers.
 
+   * Export with the =LaTeX= backend using the =minted= package for source block highlighting fails for =ipython= blocks by default with the error
+     : Error: no lexer for alias 'ipython' found
+
+     To use the =python= lexer for =ipython= blocks, add this setting:
+     #+BEGIN_SRC emacs-lisp
+       (add-to-list 'org-latex-minted-langs '(ipython "python"))
+     #+END_SRC
+
 ** Help, it doesn't work
 
    First thing to do is check that you have all of the required

--- a/README.org
+++ b/README.org
@@ -58,36 +58,18 @@
 
 *** First, you need IPython
 
-    In version 4.0, [[http://ipython.org/][IPython]] transitioned from a monolithic
-    architecture to being just one of the kernels supported by the
-    more generic [[https://jupyter.org/][Jupyter]] application framework. Beginning with version
-    4.0 of the IPython kernel, the Jupyter console application is
-    actually responsible for the REPL interface. Therefore, depending
-    on the selected or available software, the appropriate branch of
-    this repository should be selected.
-
-    If unsure, use master and an IPython install of 4.0 or greater.
-
-**** ~master~ branch for Jupyter with IPython kernel >= 4.0
-
-     Before installing, you'll need Jupyter (>= 1.0) and the IPython
-     kernel (>= 4.0) installed and working. You will also need [[http://www.tornadoweb.org/en/stable/][Tornado]]
-     and the [[http://jupyter.readthedocs.org/en/latest/install.html][Jupyter]] console and client (~jupyter_console~,
-     ~jupyter_client~) libraries.
-
-**** ~ipython3~ branch for IPython >=3.0 && < 4.0
-
-     If you're on IPython 3, you can use the ~ipython3~ branch of this
-     repository. You will also need the [[http://www.tornadoweb.org/en/stable/][Tornado]] and [[https://zeromq.github.io/pyzmq/][PyZMQ]] libraries.
-     These libraries are usually installed as dependencies of the
-     ipython notebook.
+    Before installing, you'll need Jupyter (>= 1.0) and the IPython
+    kernel (>= 5.0) installed and working. You will also need [[http://www.tornadoweb.org/en/stable/][Tornado]]
+    and the [[http://jupyter.readthedocs.org/en/latest/install.html][Jupyter]] console and client (~jupyter_console~,
+    ~jupyter_client~) libraries. All of this should be trivially
+    installable using pip.
 
 *** Install the Emacs plugin
 
-    This package is now in MELPA. I recommend installing from there.
+    This package is in MELPA. I recommend installing from there.
 
-    For manual installation, you'll need the following elisp
-    dependencies first:
+    Otherwise, for manual installation, you'll need the following
+    elisp dependencies first:
 
     * https://github.com/magnars/dash.el
         * Including dash-functional
@@ -95,7 +77,9 @@
     * https://github.com/rejeep/f.el
 
     Then just drop this somewhere in your load path and ~(require
-    'ob-ipython)~. Lastly, activate ~ipython~ in Org-Babel:
+    'ob-ipython)~.
+
+    Lastly, activate ~ipython~ in Org-Babel:
 
     #+BEGIN_SRC emacs-lisp
       (org-babel-do-load-languages

--- a/README.org
+++ b/README.org
@@ -238,6 +238,8 @@
        (add-to-list 'org-latex-minted-langs '(ipython "python"))
      #+END_SRC
 
+   * Use [[https://pypi.python.org/pypi/tabulate][tabulate]] to output data frames for org mode.
+
 ** Help, it doesn't work
 
    First thing to do is check that you have all of the required

--- a/README.org
+++ b/README.org
@@ -95,13 +95,13 @@
     * https://github.com/rejeep/f.el
 
     Then just drop this somewhere in your load path and ~(require
-    'ob-ipython)~. Also active ~ipython~ languages in Org-Babel:
+    'ob-ipython)~. Lastly, activate ~ipython~ in Org-Babel:
 
     #+BEGIN_SRC emacs-lisp
       (org-babel-do-load-languages
        'org-babel-load-languages
        '((ipython . t)
-        ;(... other languages . t)
+         ;; other languages..
          ))
     #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -97,6 +97,8 @@
 
    This is the most basic ipython block. You *must* provide a session
    argument. You can name the session if you wish to separate state.
+   You can also pass an connection json of existing ipython session
+   as a session name in order to connect to it.
 
    #+BEGIN_SRC org
      ,#+BEGIN_SRC ipython :session

--- a/README.org
+++ b/README.org
@@ -173,6 +173,16 @@
      : (2, [['a', 1, 2], ['b', 2, 3], ['c', 3, 4]])
    #+END_SRC
 
+   Asynchronous execution is supported. Use the ~:async t~ option.
+
+   #+BEGIN_SRC org
+     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :async t
+       import time
+       time.sleep(3)
+       plt.hist(np.random.randn(20000), bins=200)
+     ,#+END_SRC
+   #+END_SRC
+
 ** What features are there outside of Org SRC block evaluation?
 
    * You can ask the running IPython kernel for documentation. Open a

--- a/README.org
+++ b/README.org
@@ -94,7 +94,16 @@
     * https://github.com/magnars/s.el
     * https://github.com/rejeep/f.el
 
-    Then just drop this somewhere in your load path and ~(require 'ob-ipython)~.
+    Then just drop this somewhere in your load path and ~(require
+    'ob-ipython)~. Also active ~ipython~ languages in Org-Babel:
+
+    #+BEGIN_SRC emacs-lisp
+      (org-babel-do-load-languages
+       'org-babel-load-languages
+       '((ipython . t)
+        ;(... other languages . t)
+         ))
+    #+END_SRC
 
 ** How do I use it?
 

--- a/driver.py
+++ b/driver.py
@@ -53,7 +53,11 @@ def msg_router(name, ch):
 clients = {}
 
 def create_client(name):
-    cf = find_connection_file('emacs-' + name)
+    if name.endswith('.json'):
+        # Received an existing kernel we should connect to.
+        cf = find_connection_file(name)
+    else:
+        cf = find_connection_file('emacs-' + name)
     c = client.BlockingKernelClient(connection_file=cf)
     c.load_connection_file()
     c.start_channels()
@@ -117,10 +121,10 @@ class DebugHandler(tornado.web.RequestHandler):
 
 def make_app():
     return tornado.web.Application([
-        tornado.web.url(r"/execute/(\w+)", ExecuteHandler),
-        tornado.web.url(r"/inspect/(\w+)", InspectHandler),
+        tornado.web.url(r"/execute/([\w\-\.]+)", ExecuteHandler),
+        tornado.web.url(r"/inspect/([\w\-\.]+)", InspectHandler),
         tornado.web.url(r"/debug", DebugHandler),
-        ])
+    ])
 
 def main(args):
     parser = argparse.ArgumentParser()

--- a/driver.py
+++ b/driver.py
@@ -127,7 +127,10 @@ def main(args):
     parser.add_argument('--port', type=int)
     parser.add_argument('--kernel')
     parser.add_argument('--conn-file')
+
+    parser.add_argument('positional', nargs='*')
     args = parser.parse_args()
+    extra_arguments = args.positional
     if args.conn_file:
         if runtime_dir:
             conn_file = (args.conn_file if os.path.isabs(args.conn_file)
@@ -153,7 +156,7 @@ def main(args):
             # Emacs sends SIGHUP upon exit
             signal.signal(signal.SIGHUP, onsignal)
 
-        manager.start_kernel()
+        manager.start_kernel(extra_arguments=extra_arguments)
         try:
             semaphore.acquire()
         except KeyboardInterrupt: pass

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -177,8 +177,13 @@
   (get-process "client-driver"))
 
 (defun ob-ipython--create-repl (name)
-  (run-python (s-join " " (ob-ipython--kernel-repl-cmd name)) nil nil)
-  (format "*%s*" python-shell-buffer-name))
+  ;; TODO: hack while we wait on
+  ;; https://github.com/jupyter/jupyter_console/issues/93
+  (let ((prev (getenv "JUPYTER_CONSOLE_TEST")))
+    (setenv "JUPYTER_CONSOLE_TEST" "1")
+    (run-python (s-join " " (ob-ipython--kernel-repl-cmd name)) nil nil)
+    (setenv "JUPYTER_CONSOLE_TEST" prev)
+    (format "*%s*" python-shell-buffer-name)))
 
 ;;; kernel management
 

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -144,7 +144,11 @@
     (apply 'ob-ipython--launch-driver
            (append (list (format "kernel-%s" name))
                    (list "--conn-file" (format "emacs-%s.json" name))
-                   (if kernel (list "--kernel" kernel) '())))))
+                   (if kernel (list "--kernel" kernel) '())
+                   ;;should be last in the list of args
+                   (if ob-ipython-kernel-extra-args
+                       (list "--") '())
+                   ob-ipython-kernel-extra-args))))
 
 (defun ob-ipython--get-kernel-processes ()
   (let ((procs (-filter (lambda (p)

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -402,13 +402,14 @@ a new kernel will be started."
     (if orig-org-src-lang-mode
         (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
                                            (intern (car orig-org-src-lang-mode))) .
-                                           ,(cdr orig-org-src-lang-mode)))))
+                                           ,(cdr orig-org-src-lang-mode))))
+          (add-to-list 'org-src-lang-modes new-org-src-lang-mode))
       (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
                                         (intern language)) .
                                         ,(intern (replace-regexp-in-string
-                                                 "[0-9]" ""
-                                                 kernel)))))))
-    (add-to-list 'org-src-lang-modes 'new-org-src-lang-mode)))
+                                                 "[0-9]*" ""
+                                                 language)))))
+        (add-to-list 'org-src-lang-modes new-org-src-lang-mode)))))
 
 (defun ob-ipython-auto-configure-kernels (&optional replace)
   "Detects jupyter kernels installed on your system and configures them for use in org-babel.

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -461,7 +461,9 @@ Make sure your src block has a :session param.")
           (re-search-forward sentinel)
           (org-babel-previous-src-block)
           (org-babel-remove-result)
-          (org-babel-insert-result replacement))))))
+          (org-babel-insert-result
+           replacement
+           (cdr (assoc :result-params (nth 2 (org-babel-get-src-block-info))))))))))
 
 ;; lib
 

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -360,6 +360,67 @@ a new kernel will be started."
 
 (add-to-list 'org-src-lang-modes '("ipython" . python))
 
+;; Configure jupyter-<language> blocks for each installed kernel
+(defun ob-ipython-detect-kernels (&optional replace)
+  "Detect jupyter kernels if they are not specified in `ob-ipython-active-kernels`.
+   With optional `replace` replace`ob-ipython-active-kernels` even if it is
+   already populated."
+  (when (or replace (not ob-ipython-active-kernels))
+    (let ((jupyter-executable (executable-find "jupyter")))
+      (when jupyter-executable
+        (let ((jupyter-kernelspec-json
+               (cdr (car (json-read-from-string
+                          (shell-command-to-string
+                           (concat jupyter-executable
+                                   " kernelspec list --json")))))))
+          (let ((jupyter-kernelspecs nil))
+            (dolist (x jupyter-kernelspec-json)
+              (add-to-list 'jupyter-kernelspecs
+                           (list (car x) (cdr (assoc 'language (assoc 'spec x))))))
+            (defcustom ob-ipython-active-kernels jupyter-kernelspecs
+              "A `plist` containing language and kernel name pairs.
+   This list is used by `ob-ipython-auto-configure-kernels` to configure
+   org-bable to execute juypter kernel blocks and to associate jupyter kernal
+   blocks with the correct emacs mode for editing."
+              :group 'ob-ipython)
+           ; (setq ob-ipython-active-kernels jupyter-kernelspecs)
+            ))))))
+
+(ob-ipython-detect-kernels t)
+
+(defun ob-ipython-configure-kernel (kernel language)
+  "Configure org mode to use specified kernel."
+  (set (intern (format "org-babel-default-header-args:jupyter-%S"
+                       (intern language)))
+       `((:session . ,language)
+         (:kernel . ,kernel)
+         (:results . "output")))
+  (defalias (intern (format "org-babel-execute:jupyter-%S"
+                            (intern language)))
+    'org-babel-execute:ipython)
+  (let ((orig-org-src-lang-mode (assoc language org-src-lang-modes)))
+    (if orig-org-src-lang-mode
+        (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
+                                           (intern (car orig-org-src-lang-mode))) .
+                                           ,(cdr orig-org-src-lang-mode)))))
+      (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
+                                        (intern language)) .
+                                        ,(intern (replace-regexp-in-string
+                                                 "[0-9]" ""
+                                                 kernel)))))))
+    (add-to-list 'org-src-lang-modes 'new-org-src-lang-mode)))
+
+(defun ob-ipython-auto-configure-kernels (&optional replace)
+  "Detects jupyter kernels installed on your system and configures them for use in org-babel.
+   With &optional argument `replace` use auto-detected kernels, otherwise configure kernels
+   specified in `ob-ipython-active-kernels`."
+  (interactive)
+  (ob-ipython-detect-kernels replace)
+  (dolist (kernel ob-ipython-active-kernels)
+    (ob-ipython-configure-kernel (symbol-name (car kernel)) (car (cdr kernel)))))
+
+(add-hook 'org-mode-hook 'ob-ipython-auto-configure-kernels)
+
 (defvar org-babel-default-header-args:ipython '())
 
 (defun ob-ipython--normalize-session (session)

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -332,7 +332,13 @@ This function is called by `org-babel-execute-src-block'."
                 ((and file (string= (f-ext file) "svg"))
                  (->> result (assoc 'image/svg+xml) cdr (ob-ipython--write-string-to-file file)))
                 (file (error "%s is currently an unsupported file extension." (f-ext file)))
-                (t (->> result (assoc 'text/plain) cdr))))))))
+                (t (->> result reverse (assoc 'text/plain) cdr ob-ipython--table-or-string))))))))
+
+(defun ob-ipython--table-or-string (results)
+  "Extract an Org table from RESULTS if it looks like it might be
+a table."
+  (when results
+    (org-babel-python-table-or-string results)))
 
 (defun org-babel-prep-session:ipython (session params)
   "Prepare SESSION according to the header arguments in PARAMS.

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -63,7 +63,7 @@
   :group 'ob-ipython)
 
 (defcustom ob-ipython-command
-  "ipython"
+  "jupyter"
   "Command to launch ipython. Usually ipython or jupyter."
   :group 'ob-ipython)
 

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -385,7 +385,7 @@ This function is called by `org-babel-execute-src-block'."
                                     params (org-babel-variable-assignments:python params))
      (ob-ipython--normalize-session session)
      (lambda (ret sentinel buffer file result-type)
-  (let ((replacement (ob-ipython--process-response ret file result-type)))
+       (let ((replacement (ob-ipython--process-response ret file result-type)))
          (when (null file)
            (ipython--async-replace-sentinel sentinel buffer
                                             replacement))))
@@ -417,7 +417,6 @@ This function is called by `org-babel-execute-src-block'."
 
 ;;; TODO: we create a new image every time
 (defun ob-ipython--render (file-or-nil values)
-  (debug-msg values)
   (-some (lambda (value)
            (cond ((eq (car value) 'image/png)
                   (let ((file (or file-or-nil (ob-ipython--generate-file-name ".png"))))


### PR DESCRIPTION
This is a first pass at addressing some of the goals in https://github.com/gregsexton/ob-ipython/issues/57. Specifically it
- detects installed kernels
- adds `jupyter-<language>` entries to `org-src-lang-modes` for each detected kernel
- sets default `kernel`m `results` and `session` values for each detected kernel in `org-babel-default-header-args:jupyter-<language>`
- aliases `org-babel-execute:jupyter-<language>` to `org-babel-execute:ipython` for each detected kernel

The upshot is that you can now write 

```
#+BEGIN_SRC jupyter-python 
  print("hello from python")
#+END_SRC

#+BEGIN_SRC jupyter-R
  print("hello from R"
#+END_SRC

#+BEGIN_SRC jupyter-julia
  println("hello from julia")
#+END_SRC
```

instead of

```
#+BEGIN_SRC ipython :kernel python :results output :session python
  print("hello from python")
#+END_SRC

#+BEGIN_SRC ipython :kernel ir :results output :session r
  print("hello from R"
#+END_SRC

#+BEGIN_SRC ipython :kernel julia-4.0 :results output :session julia
  println("hello from julia")
#+END_SRC
```

In addition, editing code blocks with `C-c '` (or `M-x org-edit-special`) will now (usually) put you in the correct mode.

This PR is probably not ready to be merged. My emacs-lisp is not good, I basically just tried stuff, got error messages, tried stuff to make the errors go away, and repeated until it worked. I would very much appreciate suggestions for improving this code. My hope is that despite my obvious lack of elisp skills this PR can serve as a starting point for improving multi-kernel support in ob-ipython.
