### PR TITLE
Encode text of a block variables

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -169,7 +169,7 @@ can be displayed.")
   (when (not (ignore-errors (process-live-p (get-process (format "kernel-%s" name)))))
     (ob-ipython--create-process
      (format "kernel-%s" name)
-     (append 
+     (append
       (list ob-ipython-command "console" "--simple-prompt")
       (list "-f" (ob-ipython--kernel-file name))
       (if kernel (list "--kernel" kernel) '())
@@ -458,6 +458,12 @@ This function is called by `org-babel-execute-src-block'."
       (ob-ipython--execute-async body params)
     (ob-ipython--execute-sync body params)))
 
+(defun ob-ipython--expand-body (body params)
+  (org-babel-expand-body:generic (encode-coding-string body 'utf-8)
+                                 params
+                                 (mapcar (lambda (v) (encode-coding-string v 'utf-8))
+                                         (org-babel-variable-assignments:python params))))
+
 (defun ob-ipython--execute-async (body params)
   (let* ((file (cdr (assoc :ipyfile params)))
          (session (cdr (assoc :session params)))
@@ -466,8 +472,7 @@ This function is called by `org-babel-execute-src-block'."
     (ob-ipython--create-kernel (ob-ipython--normalize-session session)
                                (cdr (assoc :kernel params)))
     (ob-ipython--execute-request-async
-     (org-babel-expand-body:generic (encode-coding-string body 'utf-8)
-                                    params (org-babel-variable-assignments:python params))
+     (ob-ipython--expand-body body params)
      (ob-ipython--normalize-session session)
      (lambda (ret sentinel buffer file result-type)
        (let ((replacement (ob-ipython--process-response ret file result-type)))
@@ -483,8 +488,7 @@ This function is called by `org-babel-execute-src-block'."
                                (cdr (assoc :kernel params)))
     (-when-let (ret (ob-ipython--eval
                      (ob-ipython--execute-request
-                      (org-babel-expand-body:generic (encode-coding-string body 'utf-8)
-                                                     params (org-babel-variable-assignments:python params))
+                      (ob-ipython--expand-body body params)
                       (ob-ipython--normalize-session session))))
       (ob-ipython--process-response ret file result-type))))
 


### PR DESCRIPTION
fix #105
related to #17 
Example:
```
#+BEGIN_SRC ipython :session :var v="я"
1
#+END_SRC
```
Error:
```
error in process sentinel: Multibyte text in HTTP request: POST /execute/default HTTP/1.1
MIME-Version: 1.0
Connection: keep-alive
Extension: Security/Digest Security/SSL
Host: localhost:9988
Accept-encoding: gzip
Accept: */*
User-Agent: URL/Emacs
Content-length: 7

v="я"
1
```