### PR TITLE
Use result parameters from a source block when replacing sentinel

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -461,7 +461,9 @@ Make sure your src block has a :session param.")
           (re-search-forward sentinel)
           (org-babel-previous-src-block)
           (org-babel-remove-result)
-          (org-babel-insert-result replacement))))))
+          (org-babel-insert-result
+           replacement
+           (cdr (assoc :result-params (nth 2 (org-babel-get-src-block-info))))))))))
 
 ;; lib
 


### PR DESCRIPTION
Example:
```
#+BEGIN_SRC ipython :session :results drawer :async t
2
#+END_SRC
```

Expected result:

```
#+RESULTS:
:RESULTS:
2
:END:
```
Actual result:
```
#+RESULTS:
: 2
```