### PR TITLE
Place result properly when calling a named code block via #+CALL

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -583,7 +583,7 @@ Make sure your src block has a :session param.")
         (with-current-buffer buffer
           (goto-char (point-min))
           (re-search-forward sentinel)
-          (org-babel-previous-src-block)
+          (re-search-backward "\\(call\\|src\\)_\\|^[ \t]*#\\+\\(BEGIN_SRC\\|CALL:\\)")
           (org-babel-remove-result)
           (org-babel-insert-result
            replacement


### PR DESCRIPTION
Also, this fix covers inline calls (call_*) and inline code blocks (src_*).

I have tested on this org [file](https://gist.githubusercontent.com/dvzubarev/00709b80e7b592f46d1b2b5257af2e6c/raw/c0df38dc2a33d080a72957fd27d6bfddd12aabb3/27-190222.org)