### PR TITLE
Update to auto configure code

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,51 +5,6 @@
    An Emacs library that allows Org mode to evaluate code blocks using
    a Jupyter kernel (Python by default).
 
-*** Why not use IPython notebook?
-
-    I tried using the IPython notebook but quickly became frustrated
-    with trying to write code in a web browser. This provides another
-    option for creating documents containing executable Python code,
-    but in Emacs - with everything that entails.
-
-*** Why not use [[https://millejoh.github.io/emacs-ipython-notebook/][EIN]]?
-
-    EIN is really great. It kept me happy for quite a while but I
-    started to feel constrained by the cell format of IPython
-    notebooks. What I really wanted was to embed code in Org
-    documents. It's hard to compete with Org mode! A few key points in
-    favour of Org:
-
-    * In my opinion, Org's markup is better than Markdown.
-    * Org's organisational, editing and navigation facilities are much
-      better than EIN.
-    * Org's tables...
-    * Org can export to multiple formats.
-    * I like how Org opens a new buffer when editing code so that you
-      can use a Python major mode rather than trying to handle
-      multiple major modes in one.
-
-    I also found myself hitting bugs in EIN where evaluation and doc
-    lookup would just stop working. I regularly had to kill and reopen
-    buffers or restart the IPython kernel and this was getting
-    frustrating.
-
-*** How does this compare to regular Org Python integration (ob-python)?
-
-    I think this is more robust. The executed code is sent to a
-    running IPython kernel which has an architecture designed for this
-    purpose. The way ob-python works feels like a bit of a hack. I ran
-    in to race conditions using ob-python where the Org buffer would
-    update its results before the Python REPL had finished evaluating
-    the code block. This is what eventually drove me to write this.
-
-    It's easier to get plots and images out of this. I also provide
-    several features I missed when using plain ob-python, such as
-    looking up documentation and getting IPython-style tracebacks when
-    things go wrong.
-
-    You can also use IPython-specific features such as ~%timeit~.
-
 ** Screenshot
 
    [[./screenshot.jpg]]
@@ -97,11 +52,14 @@
 
    This is the most basic ipython block. You *must* provide a session
    argument. You can name the session if you wish to separate state.
-   You can also pass an connection json of existing ipython session
+   You can also pass a connection json of an existing ipython session
    as a session name in order to connect to it.
 
+   The result returned by ob-ipython should be renderable by org so
+   it's recommended to always use ~:results raw drawer~.
+
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session
+     ,#+BEGIN_SRC ipython :session :results raw drawer
        %matplotlib inline
        import matplotlib.pyplot as plt
        import numpy as np
@@ -112,7 +70,7 @@
    session.
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session mysession :exports both
+     ,#+BEGIN_SRC ipython :session mysession :exports both :results raw drawer
        def foo(x):
            return x + 9
 
@@ -123,12 +81,22 @@
      : [16, 17, 18, 19, 20, 21, 22]
    #+END_SRC
 
-   This is how you can get a graphic out. Notice the file argument.
-   This must be provided. You must also ensure that you have evaluated
-   ~%matplotlib inline~ before evaluating this.
+   To get a graphic out, you must ensure that you have evaluated
+   ~%matplotlib inline~ first. A file will be generated for you (see
+   the ~ob-ipython-resources-dir~ custom var if you want to change the
+   path).
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both
+     ,#+BEGIN_SRC ipython :session :exports both :results raw drawer
+       plt.hist(np.random.randn(20000), bins=200)
+     ,#+END_SRC
+   #+END_SRC
+
+   If you provide a file argument, this will be used instead of
+   generating one.
+
+   #+BEGIN_SRC org
+     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :results raw drawer
        plt.hist(np.random.randn(20000), bins=200)
      ,#+END_SRC
    #+END_SRC
@@ -176,7 +144,7 @@
    Asynchronous execution is supported. Use the ~:async t~ option.
 
    #+BEGIN_SRC org
-     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :async t
+     ,#+BEGIN_SRC ipython :session :file /tmp/image.png :exports both :async t :results raw drawer
        import time
        time.sleep(3)
        plt.hist(np.random.randn(20000), bins=200)
@@ -210,8 +178,8 @@
 
 ** Tips and tricks
 
-   Here are a few things I've setup to make life better. These aren't
-   provided with ob-ipython but are recommended.
+   Here are a few things I have setup to make life better. These
+   aren't provided with ob-ipython, but are recommended.
 
    * Be sure to use ~%matplotlib inline~, otherwise graphics won't work.
 
@@ -248,7 +216,9 @@
        (add-to-list 'org-latex-minted-langs '(ipython "python"))
      #+END_SRC
 
-   * Use [[https://pypi.python.org/pypi/tabulate][tabulate]] to output data frames for org mode.
+   * Install pandoc and anything ipython renders as html will be
+     converted to org. This is mostly useful for getting nice tables
+     automatically.
 
 ** Help, it doesn't work
 
@@ -257,3 +227,49 @@
    project's issues, so take a look there to see if your problem has a
    quick fix. Otherwise feel free to cut an issue - I'll do my best to
    help.
+
+** Alternatives
+*** Why not use IPython notebook?
+
+    I tried using the IPython notebook but quickly became frustrated
+    with trying to write code in a web browser. This provides another
+    option for creating documents containing executable Python code,
+    but in Emacs - with everything that entails.
+
+*** Why not use [[https://millejoh.github.io/emacs-ipython-notebook/][EIN]]?
+
+    EIN is really great. It kept me happy for quite a while but I
+    started to feel constrained by the cell format of IPython
+    notebooks. What I really wanted was to embed code in Org
+    documents. It's hard to compete with Org mode! A few key points in
+    favour of Org:
+
+    * In my opinion, Org's markup is better than Markdown.
+    * Org's organisational, editing and navigation facilities are much
+      better than EIN.
+    * Org's tables...
+    * Org can export to multiple formats.
+    * I like how Org opens a new buffer when editing code so that you
+      can use a Python major mode rather than trying to handle
+      multiple major modes in one.
+
+    I also found myself hitting bugs in EIN where evaluation and doc
+    lookup would just stop working. I regularly had to kill and reopen
+    buffers or restart the IPython kernel and this was getting
+    frustrating.
+
+*** How does this compare to regular Org Python integration (ob-python)?
+
+    I think this is more robust. The executed code is sent to a
+    running IPython kernel which has an architecture designed for this
+    purpose. The way ob-python works feels like a bit of a hack. I ran
+    in to race conditions using ob-python where the Org buffer would
+    update its results before the Python REPL had finished evaluating
+    the code block. This is what eventually drove me to write this.
+
+    It's easier to get plots and images out of this. I also provide
+    several features I missed when using plain ob-python, such as
+    looking up documentation and getting IPython-style tracebacks when
+    things go wrong.
+
+    You can also use IPython-specific features such as ~%timeit~.

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -402,13 +402,14 @@ a new kernel will be started."
     (if orig-org-src-lang-mode
         (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
                                            (intern (car orig-org-src-lang-mode))) .
-                                           ,(cdr orig-org-src-lang-mode)))))
+                                           ,(cdr orig-org-src-lang-mode))))
+          (add-to-list 'org-src-lang-modes new-org-src-lang-mode))
       (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
                                         (intern language)) .
                                         ,(intern (replace-regexp-in-string
-                                                 "[0-9]" ""
-                                                 kernel)))))))
-    (add-to-list 'org-src-lang-modes 'new-org-src-lang-mode)))
+                                                 "[0-9]*" ""
+                                                 language)))))
+        (add-to-list 'org-src-lang-modes new-org-src-lang-mode)))))
 
 (defun ob-ipython-auto-configure-kernels (&optional replace)
   "Detects jupyter kernels installed on your system and configures them for use in org-babel.

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -360,6 +360,67 @@ a new kernel will be started."
 
 (add-to-list 'org-src-lang-modes '("ipython" . python))
 
+;; Configure jupyter-<language> blocks for each installed kernel
+(defun ob-ipython-detect-kernels (&optional replace)
+  "Detect jupyter kernels if they are not specified in `ob-ipython-active-kernels`.
+   With optional `replace` replace`ob-ipython-active-kernels` even if it is
+   already populated."
+  (when (or replace (not ob-ipython-active-kernels))
+    (let ((jupyter-executable (executable-find "jupyter")))
+      (when jupyter-executable
+        (let ((jupyter-kernelspec-json
+               (cdr (car (json-read-from-string
+                          (shell-command-to-string
+                           (concat jupyter-executable
+                                   " kernelspec list --json")))))))
+          (let ((jupyter-kernelspecs nil))
+            (dolist (x jupyter-kernelspec-json)
+              (add-to-list 'jupyter-kernelspecs
+                           (list (car x) (cdr (assoc 'language (assoc 'spec x))))))
+            (defcustom ob-ipython-active-kernels jupyter-kernelspecs
+              "A `plist` containing language and kernel name pairs.
+   This list is used by `ob-ipython-auto-configure-kernels` to configure
+   org-bable to execute juypter kernel blocks and to associate jupyter kernal
+   blocks with the correct emacs mode for editing."
+              :group 'ob-ipython)
+           ; (setq ob-ipython-active-kernels jupyter-kernelspecs)
+            ))))))
+
+(ob-ipython-detect-kernels t)
+
+(defun ob-ipython-configure-kernel (kernel language)
+  "Configure org mode to use specified kernel."
+  (set (intern (format "org-babel-default-header-args:jupyter-%S"
+                       (intern language)))
+       `((:session . ,language)
+         (:kernel . ,kernel)
+         (:results . "output")))
+  (defalias (intern (format "org-babel-execute:jupyter-%S"
+                            (intern language)))
+    'org-babel-execute:ipython)
+  (let ((orig-org-src-lang-mode (assoc language org-src-lang-modes)))
+    (if orig-org-src-lang-mode
+        (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
+                                           (intern (car orig-org-src-lang-mode))) .
+                                           ,(cdr orig-org-src-lang-mode)))))
+      (let ((new-org-src-lang-mode `(,(format "jupyter-%S"
+                                        (intern language)) .
+                                        ,(intern (replace-regexp-in-string
+                                                 "[0-9]" ""
+                                                 kernel)))))))
+    (add-to-list 'org-src-lang-modes 'new-org-src-lang-mode)))
+
+(defun ob-ipython-auto-configure-kernels (&optional replace)
+  "Detects jupyter kernels installed on your system and configures them for use in org-babel.
+   With &optional argument `replace` use auto-detected kernels, otherwise configure kernels
+   specified in `ob-ipython-active-kernels`."
+  (interactive)
+  (ob-ipython-detect-kernels replace)
+  (dolist (kernel ob-ipython-active-kernels)
+    (ob-ipython-configure-kernel (symbol-name (car kernel)) (car (cdr kernel)))))
+
+(add-hook 'org-mode-hook 'ob-ipython-auto-configure-kernels)
+
 (defvar org-babel-default-header-args:ipython '())
 
 (defun ob-ipython--normalize-session (session)

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -385,7 +385,7 @@ This function is called by `org-babel-execute-src-block'."
                                     params (org-babel-variable-assignments:python params))
      (ob-ipython--normalize-session session)
      (lambda (ret sentinel buffer file result-type)
-  (let ((replacement (ob-ipython--process-response ret file result-type)))
+       (let ((replacement (ob-ipython--process-response ret file result-type)))
          (when (null file)
            (ipython--async-replace-sentinel sentinel buffer
                                             replacement))))
@@ -417,7 +417,6 @@ This function is called by `org-babel-execute-src-block'."
 
 ;;; TODO: we create a new image every time
 (defun ob-ipython--render (file-or-nil values)
-  (debug-msg values)
   (-some (lambda (value)
            (cond ((eq (car value) 'image/png)
                   (let ((file (or file-or-nil (ob-ipython--generate-file-name ".png"))))


### PR DESCRIPTION
This is essentially a refactor of #74 to be more in line with the code style of the project and a few minor changes.

The whole process of auto configuring kernels as it currently stands involves the following steps:
1. Parsing the kernel name and language from the output of `jupyter kernelspec list --json`
2. Adding `jupyter-<language>` to `org-src-lang-modes` if not already present. In the case that `<language>` already exists in `org-src-lang-modes` use the corresponding mode for the language when adding `jupyter-<language>`.
3. Set `org-babel-default-header-args:jupyter-<language>` to a default value if not already set. The default consists of setting the `:session` and `:kernel` header args where the default `:session` is just `"<language>"`. 
4. Aliasing the `org-babel` functions for `jupyter-<language>` to the `ipython` versions that are currently implemented. 

