### PR TITLE
Added documentation re: json-readtable-error to help debug it

### DIFF
--- a/README.org
+++ b/README.org
@@ -302,6 +302,18 @@ Essentially the instructions boil down to
    quick fix. Otherwise feel free to cut an issue - I'll do my best to
    help.
 
+*** When I start Emacs or initialize =ob-ipython=, I get =json-readtable-error=
+   
+   If you get this error, there's most likely a problem with Emacs talking to =jupyter= or
+   =ipython=. Try running ~M-! jupyter --version~ and see what you get. If you get a message indicating
+   that it didn't recognize =jupyter=, then try making sure you've configured your PATH correctly with
+   something like [[https://github.com/purcell/exec-path-from-shell][exec-path-from-shell]].
+
+   If this doesn't work, get exactly what is going wrong by invoking ~M-x debug-on-entry RET
+   json-read~ followed by triggering the bug. This should help narrow down what exactly is going
+   wrong. Check your virtualenv and make sure that the ~M-! jupyter --version~ command from earlier
+   isn't returning garbled text.
+
 ** Alternatives
 *** Why not use IPython notebook?
 


### PR DESCRIPTION
Added documentation to errors reading JSON that explains how to find the root cause of the error. The problem is that _any_ issue in the subprocess call will return the same cryptic error, so it's difficult to debug. Perhaps it's possible to make this give a better error message in Emacs itself, but doing that across the various places JSON can be read would be challenging: it's good to have a documentation snippet about it in that case.