### PR TITLE
change kernel and REPL naming conventions

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -618,7 +618,7 @@ have previously been configured."
            (session (cdr (assoc :session params))))
       (if (s-ends-with? ".json" session)
           session
-        (format "emacs-%s-%s.json"
+        (format "%s-%s"
                 (ob-ipython--get-display-name kernel)
                 (ob-ipython--normalize-session session))))))
 
@@ -643,7 +643,7 @@ This function is called by `org-babel-execute-src-block'."
                                     params (org-babel-variable-assignments:python params))
      (if (s-ends-with? ".json" session)
          session
-       (format "emacs-%s-%s.json"
+       (format "%s-%s"
                (ob-ipython--get-display-name kernel)
                (ob-ipython--normalize-session session)))
      (lambda (ret sentinel buffer file result-type)
@@ -665,7 +665,7 @@ This function is called by `org-babel-execute-src-block'."
                                                      params (org-babel-variable-assignments:python params))
                       (if (s-ends-with? ".json" session)
                           session
-                        (format "emacs-%s-%s.json"
+                        (format "%s-%s"
                                 (ob-ipython--get-display-name kernel)
                                 (ob-ipython--normalize-session session))))))
       (ob-ipython--process-response ret file result-type))))

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -563,11 +563,11 @@ and display names. The elements of the list have the form (\"kernel\" \"language
   (or (capitalize (nth 2 (assoc kernel ob-ipython-configured-kernels)))
       (capitalize kernel)))
 
-(defun ob-ipython--configure-kernel (kernel-lang)
+(defun ob-ipython--configure-kernel (kernel-lang-display)
   "Configure org mode to use specified kernel."
-  (let* ((kernel (car kernel-lang))
-         (language (nth 1 kernel-lang))
-         (display-name (nth 2 kernel-lang))
+  (let* ((kernel (car kernel-lang-display))
+         (language (nth 1 kernel-lang-display))
+         (display-name (nth 2 kernel-lang-display))
          (jupyter-lang (concat "jupyter-" display-name))
          (mode (intern (or (cdr (assoc language org-src-lang-modes))
                            (replace-regexp-in-string "[0-9]*" "" language))))

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -560,8 +560,7 @@ and display names. The elements of the list have the form (\"kernel\" \"language
 (defun ob-ipython--get-display-name (kernel)
   "Return display-name for KERNEL."
   ;; get display-name for kernel and capitalize first letter
-  (or (capitalize (nth 2 (assoc kernel ob-ipython-configured-kernels)))
-      (capitalize kernel)))
+  (capitalize (nth 2 (assoc kernel ob-ipython-configured-kernels))))
 
 (defun ob-ipython--configure-kernel (kernel-lang-display)
   "Configure org mode to use specified kernel."
@@ -583,7 +582,7 @@ and display names. The elements of the list have the form (\"kernel\" \"language
       'org-babel-execute:ipython)
     (defalias (intern (concat "org-babel-" jupyter-lang "-initiate-session"))
       'org-babel-ipython-initiate-session)
-    kernel-lang))
+    kernel-lang-display))
 
 (defun ob-ipython-auto-configure-kernels (&optional replace)
   "Auto-configure kernels for use with org-babel based on the

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -522,10 +522,9 @@ is empty, return python2 by default."
                           (cdr))
                    (error "Can't find kernel file; make sure jupyter paths are correct and kernel file is there"))))
 
-    (if kernel
-        (if (not (length kernel))
-            "python2"
-          kernel))))
+    (if (string= "" kernel)
+        "python2"
+      kernel)))
 
 (defun ob-ipython--get-kernels ()
   "Return a list of available jupyter kernels and their corresponding languages.
@@ -602,10 +601,14 @@ have previously been configured."
 
 (defun ob-ipython--get-session-from-edit-buffer (buffer)
   (with-current-buffer buffer
-    (let ((params (nth 2 org-src--babel-info)))
-      (format "%s-%s"
-              (ob-ipython--get-language (cdr (assoc :kernel params)))
-              (ob-ipython--normalize-session (cdr (assoc :session params)))))))
+    (let* ((params (nth 2 org-src--babel-info))
+           (kernel (cdr (assoc :kernel params)))
+           (session (cdr (assoc :session params))))
+      (if (s-ends-with? ".json" session)
+          session
+        (format "emacs-%s-%s.json"
+                (ob-ipython--get-language kernel)
+                (ob-ipython--normalize-session session))))))
 
 (defun org-babel-execute:ipython (body params)
   "Execute a block of IPython code with Babel.


### PR DESCRIPTION
This PR is probably not yet ready to merge, but I'm interested in hearing if this is the direction you want to go. The main purpose of this code change is to try and unify naming conventions that make explicit the various kernels and sessions that can be spawned through Jupyter. I was experiencing some name clashes between the different kernels and sessions and so this PR attempts to eliminate them (I think) while making everyone's workflow backwards compatible (I think).  The most noticeable change is that now each kernel/session started has a name like "\<language\>-\<session\>" so that, for instance an already running default python session won't preclude starting up a default R session. This change required having every source block contain a :kernel entry, but a default header value of "python" means people used to not specifying it won't have to worry about it.  The REPLs adopt a similar naming convention of "Jupyter:\<language\>:\<session\>. The goal with this particular change is to have a future PR unambiguously connect the src edit buffers with their underlying processes.

The one change that would require altering documentation is src blocks using the jupyter-X magic will now need a :session argument. Also, when jupyter-X is specified as the language but a :kernel argument is explicitly provided, the custom :kernel entry overrides what the jupyter-X magic had done (but I think that's how it is now).

To see if everything was working as I expected it to, I tried out as many permutations of starting and stopping different kernels as I could, including ones started outside of emacs, but I'm sure there's something I overlooked.

Let me know what you think.