### PR TITLE
Log message if jupyter not found instead of json-readtable-error

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -508,7 +508,7 @@ The elements of the list have the form (\"kernel\" \"language\")."
              (condition-case-unless-debug nil
                  (cdar (json-read-from-string kernelspecs-text))
                (json-readtable-error
-                (message "Failed to list jupyter kernels with: %s" kernelspecs-cmd)
+                (message "Failed to list jupyter kernels with: %s, got:\n%s" kernelspecs-cmd kernelspecs-text)
                 nil))))
          (when kernelspecs
            (-map (lambda (spec)


### PR DESCRIPTION
To reproduce (from `emacs -Q`):
* Without jupyter installed, ensure `ob-ipython` is installed and `(require 'ob-ipython)`.
* Open an `.org` file

Expect: No error

Got: `File mode specification error: (json-readtable-error 47)`

This makes ob-ipython `message` rather than fail with a `json-readtable-error` (whose origin and cause are not so obvious) if auto-configuring jupyter kernels fails because (for example) jupyter is not installed.  The message includes both the shell command and the output of that command.

Related to #135 -- I don't think I could say it fixes it because I'm not sure that's a single issue, more of a self-help thread maybe...

The reason I personally want this is that it prevents issues like this, which occur even when the user isn't intending to use `ob-ipython` at all: https://github.com/syl20bnr/spacemacs/issues/9941
