### PR TITLE
Adapt python-shell-buffer-name in org-src edit blocks.

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -566,6 +566,10 @@ have previously been configured."
   (ob-ipython--create-kernel (->> info (nth 2) (assoc :session) cdr
                                   ob-ipython--normalize-session)
                              (->> info (nth 2) (assoc :kernel) cdr))
+  ;; Support for python.el's "send-code" commands within edit buffers.
+  (setq-local python-shell-buffer-name
+              (format "Python:%s" (->> info (nth 2) (assoc :session) cdr
+                                       ob-ipython--normalize-session)))
   (ob-ipython-mode +1))
 
 (defun ob-ipython--normalize-session (session)


### PR DESCRIPTION
The following PR adds support for `python-shell-send-*` commands from within org-src edit blocks.
Discussion [here](https://github.com/jkitchin/scimax/issues/183). 