### PR TITLE
fix mode query in kernel configuration (fixes #154)

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -533,8 +533,8 @@ The elements of the list have the form (\"kernel\" \"language\")."
   (let* ((kernel (car kernel-lang))
          (language (cdr kernel-lang))
          (jupyter-lang (concat "jupyter-" language))
-         (mode (intern (or (cdr (assoc language org-src-lang-modes))
-                           (replace-regexp-in-string "[0-9]*" "" language))))
+         (mode (or (cdr (assoc language org-src-lang-modes))
+                   (intern (replace-regexp-in-string "[0-9]*" "" language))))
          (header-args (intern (concat "org-babel-default-header-args:" jupyter-lang))))
     (add-to-list 'org-src-lang-modes `(,jupyter-lang . ,mode))
     ;; Only set defaults if the corresponding variable is nil or does not


### PR DESCRIPTION
Values in `org-src-lang-modes` are symbols, so there is no `intern`
needed (which would crash either way as it expects a string).
The error occurred if you had kernels installed, that have an entry in `org-src-lang-modes`.
See #154 