### PR TITLE
added customizable variable to suppress execution count - fixes #185

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -64,6 +64,10 @@
   "Directory where resources (e.g images) are stored so that they
 can be displayed.")
 
+(defcustom ob-ipython-suppress-execution-count nil
+  "If non-nil do not show the execution count in output."
+  :group 'ob-ipython)
+
 ;; utils
 
 (defun ob-ipython--write-string-to-file (file string)
@@ -626,11 +630,13 @@ This function is called by `org-babel-execute-src-block'."
         output
       (ob-ipython--output output nil)
       (s-concat
-       (format "# Out[%d]:\n" (cdr (assoc :exec-count ret)))
-       (s-join "\n" (->> (-map (-partial 'ob-ipython--render file)
-                               (list (cdr (assoc :value result))
-                                     (cdr (assoc :display result))))
-                         (remove-if-not nil)))))))
+       (if ob-ipython-suppress-execution-count
+	   ""
+	 (format "# Out[%d]:\n" (cdr (assoc :exec-count ret)))
+	 (s-join "\n" (->> (-map (-partial 'ob-ipython--render file)
+				 (list (cdr (assoc :value result))
+				       (cdr (assoc :display result))))
+			   (remove-if-not nil)))))))
 
 (defun ob-ipython--render (file-or-nil values)
   (let ((org (lambda (value) value))

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -636,7 +636,7 @@ This function is called by `org-babel-execute-src-block'."
 	 (s-join "\n" (->> (-map (-partial 'ob-ipython--render file)
 				 (list (cdr (assoc :value result))
 				       (cdr (assoc :display result))))
-			   (remove-if-not nil)))))))
+			   (remove-if-not nil))))))))
 
 (defun ob-ipython--render (file-or-nil values)
   (let ((org (lambda (value) value))


### PR DESCRIPTION
This PR adds a custom variable to be able to suppress the execution count of ipython (i.e. "Out[n]:" line).
Was inspired from the work by @jkitchin in `scimax-org-babel-ipython-upstream.el` and seemed simple enough for me to bring into the upstream ob-ipython that scimax can depend on.

Closes #185.