### PR TITLE
add a version number for pkg-info-version-info - fixes #72

### DIFF
--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -1,6 +1,7 @@
 ;;; ob-ipython.el --- org-babel functions for IPython evaluation
 
 ;; Author: Greg Sexton <gregsexton@gmail.com>
+;; Version: 1.0.0
 ;; Keywords: literate programming, reproducible research
 ;; Homepage: http://www.gregsexton.org
 ;; Package-Requires: ((s "1.9.0") (dash "2.10.0") (dash-functional "1.2.0") (f "0.17.2") (emacs "24"))


### PR DESCRIPTION
This PR adds a version tag to ob-ipython as asked for in #72 in order to help "at some later point when things break (as they sometimes do) to find out at what point this happened".