### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,6 @@
     elisp dependencies first:
 
     * https://github.com/magnars/dash.el
-        * Including dash-functional
     * https://github.com/magnars/s.el
     * https://github.com/rejeep/f.el
 

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -3,7 +3,7 @@
 ;; Author: Greg Sexton <gregsexton@gmail.com>
 ;; Keywords: literate programming, reproducible research
 ;; Homepage: http://www.gregsexton.org
-;; Package-Requires: ((s "1.9.0") (dash "2.10.0") (dash-functional "1.2.0") (f "0.17.2") (emacs "24"))
+;; Package-Requires: ((s "1.9.0") (dash "2.18.0") (f "0.17.2") (emacs "24"))
 
 ;; The MIT License (MIT)
 
@@ -36,7 +36,6 @@
 (require 'ob)
 (require 'ob-python)
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 (require 'f)
 (require 'json)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218