### PR TITLE
setDaemon deprecated in client.py

### DIFF
--- a/client.py
+++ b/client.py
@@ -45,8 +45,7 @@ def create_client(name):
     c.load_connection_file()
     c.start_channels()
     io, shell = c.get_iopub_msg, c.get_shell_msg
-    t = threading.Thread(target=msg_router, args=(io, shell))
-    t.setDaemon(True)
+    t = threading.Thread(target=msg_router, args=(io, shell), daemon=True)
     t.start()
     return c
 

--- a/ob-ipython.el
+++ b/ob-ipython.el
@@ -630,7 +630,7 @@ This function is called by `org-babel-execute-src-block'."
        (s-join "\n" (->> (-map (-partial 'ob-ipython--render file)
                                (list (cdr (assoc :value result))
                                      (cdr (assoc :display result))))
-                         (remove-if-not nil)))))))
+                         (remove-if-not #'identity)))))))
 
 (defun ob-ipython--render (file-or-nil values)
   (let ((org (lambda (value) value))


### PR DESCRIPTION
The syntax for the daemon option of `threading.Thread` has changed in recent python3 versions, causing an error message each time `create_client is called`, which messes up the json data. This shows up as a `JSON readtable error: 47`

This change fixes it.